### PR TITLE
Add ApoorvKhanna to glama.json maintainers

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["MaruPelkar"]
+  "maintainers": ["MaruPelkar", "ApoorvKhanna"]
 }


### PR DESCRIPTION
One-line change: adds `ApoorvKhanna` alongside `MaruPelkar` in `glama.json` maintainers.

**Why:** Glama (glama.ai) lets a repo's listed maintainers claim + sync the server listing. Adding ApoorvKhanna lets him complete the Glama claim from his own GitHub account, so Vaaya can carry a Glama score badge — now required to stay listed in the `awesome-mcp-servers` directory (91k★).

No functional change to the server; `glama.json` only affects the Glama listing.